### PR TITLE
Update action.js

### DIFF
--- a/addon/actions/action.js
+++ b/addon/actions/action.js
@@ -29,6 +29,8 @@ export default EmberObject.extend({
     this._super(...arguments);
     assert('Custom actions require model property to be passed!', this.get('model'));
     assert('Custom action model has to be persisted!', !(this.get('instance') && !this.get('model.id')));
+    
+    this.options = {};
   },
 
   /**
@@ -36,20 +38,6 @@ export default EmberObject.extend({
     @return {DS.Store}
   */
   store: readOnly('model.store'),
-
-  /**
-    @public
-    @return {Object}
-  */
-  options: computed({
-    get() {
-      return {};
-    },
-
-    set(key, value) {
-      return value;
-    }
-  }),
 
   /**
     @private


### PR DESCRIPTION
Change `options` to be instance variable instead of `computed` since it is overrided later. This should fix deprecation warning.